### PR TITLE
Track use of MODULE_API macros and add isUnrealExported() AST matcher

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -264,7 +264,7 @@ protected:
   NamedDecl(Kind DK, DeclContext *DC, SourceLocation L, DeclarationName N)
       : Decl(DK, DC, L), Name(N)
       // @unreal: BEGIN
-      , UnrealType(UnrealType::UT_None), UnrealSpecifiers(), UnrealMetadata()
+        , UnrealType(UnrealType::UT_None), UnrealExported(false), UnrealSpecifiers(), UnrealMetadata()
       // @unreal: END
       {}
 
@@ -272,6 +272,12 @@ public:
   // @unreal: BEGIN
   /// The Unreal type flag for this decl.
   unsigned UnrealType;
+
+  /// If true, this type is exported from modules as far as Unreal
+  /// is concerned. This is set when _API is present on the type,
+  /// and can be used to track that _API is present regardless of
+  /// what the macro expands to.
+  bool UnrealExported;
 
   /// The Unreal specifiers that are associated with this decl.
   /// todo: Make this a map for faster lookups.

--- a/clang/include/clang/ASTMatchers/ASTMatchers.Unreal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.Unreal.h
@@ -501,4 +501,16 @@ AST_MATCHER(QualType, isExpensiveToCopy) {
   return IsExpensive && *IsExpensive;
 }
 
+/// Matches if a named decl has an ..._API macro applied to it.
+///
+/// Given
+/// \code
+///   class MYMODULE_API FSomeDecl {};
+/// \endcode
+/// \c namedDecl(isUnrealExported())
+///   matches the class.
+AST_MATCHER(NamedDecl, isUnrealExported) {
+  return Node.UnrealExported;
+}
+
 // @unreal: END

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -995,6 +995,7 @@ PRAGMA_ANNOTATION(unreal_uinterface)
 PRAGMA_ANNOTATION(unreal_ustruct)
 PRAGMA_ANNOTATION(unreal_specifier)
 PRAGMA_ANNOTATION(unreal_metadata_specifier)
+PRAGMA_ANNOTATION(unreal_exported)
 // @unreal: END
 
 #undef PRAGMA_ANNOTATION

--- a/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
@@ -18,4 +18,5 @@ REGISTER_MATCHER(isMissingDllImportOrExport);
 REGISTER_MATCHER(isPODType);
 REGISTER_MATCHER(hasRedundantNamespacing);
 REGISTER_MATCHER(isExpensiveToCopy);
+REGISTER_MATCHER(isUnrealExported);
 // @unreal: END

--- a/clang/lib/Lex/UnrealEnginePPTagger.cpp
+++ b/clang/lib/Lex/UnrealEnginePPTagger.cpp
@@ -54,30 +54,33 @@ void UnrealEnginePPTagger::MacroExpands(const Token &MacroNameTok,
                                         const MacroArgs *Args) {
   if (MacroNameTok.isAnyIdentifier()) {
     llvm::StringRef MacroName = MacroNameTok.getIdentifierInfo()->getName();
-    bool IsRecognised = false;
+    bool RequiresParameterHandling = false;
     std::vector<TokenInfo> TokensToPush;
     if (MacroName == "UCLASS") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_uclass, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "USTRUCT") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_ustruct, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "UINTERFACE") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_uinterface, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "UPROPERTY") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_uproperty, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "UFUNCTION") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_ufunction, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
+    } else if (MacroName.ends_with("_API")) {
+      TokensToPush.push_back(
+          TokenInfo(tok::TokenKind::annot_unreal_exported, nullptr));
     }
-    if (IsRecognised && Args != nullptr) {
+    if (RequiresParameterHandling && Args != nullptr) {
       assert(Args->getNumMacroArguments() == 1 &&
              "Expected U* specifier to only have one (varargs) argument");
       const Token *ArgTokens = Args->getUnexpArgument(0);

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4720,7 +4720,7 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
     // @unreal: BEGIN
     if (Tok.isOneOf(tok::annot_unreal_ufunction, tok::annot_unreal_uproperty,
                     tok::annot_unreal_specifier,
-                    tok::annot_unreal_metadata_specifier)) {
+                    tok::annot_unreal_metadata_specifier, tok::annot_unreal_exported)) {
       if (Tok.getAnnotationValue() == nullptr) {
         HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
       } else {

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3411,6 +3411,7 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclarationWithPragmas(
   case tok::annot_unreal_uproperty:
   case tok::annot_unreal_specifier:
   case tok::annot_unreal_metadata_specifier:
+  case tok::annot_unreal_exported:
     if (Tok.getAnnotationValue() == nullptr) {
       HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
     } else {

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -727,7 +727,8 @@ void Parser::ConsumePragmaUnreal() {
   while (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
                      tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
                      tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
-                     tok::annot_unreal_metadata_specifier)) {
+                     tok::annot_unreal_metadata_specifier,
+                     tok::annot_unreal_exported)) {
     if (Tok.getAnnotationValue() == nullptr) {
       HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
     } else {
@@ -741,14 +742,16 @@ void Parser::CheckNoPragmaUnreal() {
   if (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
                   tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
                   tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
-                  tok::annot_unreal_metadata_specifier)) {
+                  tok::annot_unreal_metadata_specifier,
+                  tok::annot_unreal_exported)) {
     Diag(Tok.getLocation(), diag::err_expected_member_name_or_semi)
         << SourceRange();
     assert(!Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
                         tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
                         tok::annot_unreal_uproperty,
                         tok::annot_unreal_specifier,
-                        tok::annot_unreal_metadata_specifier));
+                        tok::annot_unreal_metadata_specifier,
+                        tok::annot_unreal_exported));
   }
 }
 


### PR DESCRIPTION
This tracks the use of `MODULE_API` macros against named declarations, and provides an AST matcher `isUnrealExported()` that can be used against `NamedDecl` to see whether that macro has been applied.

This should be more reliable for finding non-exported types in `Public` folders than `isMissingDllImportOrExport`, since it won't need to be based on what the macro expands to.