### PR TITLE
Add include-what-you-use detection to find unneeded headers

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -264,7 +264,7 @@ protected:
   NamedDecl(Kind DK, DeclContext *DC, SourceLocation L, DeclarationName N)
       : Decl(DK, DC, L), Name(N)
       // @unreal: BEGIN
-      , UnrealType(UnrealType::UT_None), UnrealSpecifiers(), UnrealMetadata()
+        , UnrealType(UnrealType::UT_None), UnrealExported(false), UnrealSpecifiers(), UnrealMetadata()
       // @unreal: END
       {}
 
@@ -272,6 +272,12 @@ public:
   // @unreal: BEGIN
   /// The Unreal type flag for this decl.
   unsigned UnrealType;
+
+  /// If true, this type is exported from modules as far as Unreal
+  /// is concerned. This is set when _API is present on the type,
+  /// and can be used to track that _API is present regardless of
+  /// what the macro expands to.
+  bool UnrealExported;
 
   /// The Unreal specifiers that are associated with this decl.
   /// todo: Make this a map for faster lookups.

--- a/clang/include/clang/ASTMatchers/ASTMatchers.Unreal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.Unreal.h
@@ -501,4 +501,16 @@ AST_MATCHER(QualType, isExpensiveToCopy) {
   return IsExpensive && *IsExpensive;
 }
 
+/// Matches if a named decl has an ..._API macro applied to it.
+///
+/// Given
+/// \code
+///   class MYMODULE_API FSomeDecl {};
+/// \endcode
+/// \c namedDecl(isUnrealExported())
+///   matches the class.
+AST_MATCHER(NamedDecl, isUnrealExported) {
+  return Node.UnrealExported;
+}
+
 // @unreal: END

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1494,4 +1494,5 @@ def UnsafeBufferUsage : DiagGroup<"unsafe-buffer-usage", [UnsafeBufferUsageInCon
 
 // @unreal: BEGIN
 def UnrealEngine : DiagGroup<"unreal-engine">;
+def IncludeWhatYouUse : DiagGroup<"include-what-you-use">;
 // @unreal: END

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3467,6 +3467,15 @@ def warn_unreal_data_discarded_on_new_specifier : Warning<
   InGroup<UnrealEngine>;
 def note_unreal_data_previous_location : Note<
   "previously discarded metadata was located here">;
+def err_unreal_annotation_found_in_unexpected_place : Error<
+  "Unreal Engine macro used in unexpected place">;
+def warn_iwyu_remove_unused_header : Warning<
+  "#include header is completely unused and can be removed">, 
+  InGroup<IncludeWhatYouUse>;
+def warn_iwyu_replace_unused_header : Warning<
+  "#include header does not contain any immediate dependency "
+  "and can be replaced with an #include to '%0' instead">, 
+  InGroup<IncludeWhatYouUse>;
 // @unreal: END
 
 def err_anonymous_property: Error<

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -995,6 +995,7 @@ PRAGMA_ANNOTATION(unreal_uinterface)
 PRAGMA_ANNOTATION(unreal_ustruct)
 PRAGMA_ANNOTATION(unreal_specifier)
 PRAGMA_ANNOTATION(unreal_metadata_specifier)
+PRAGMA_ANNOTATION(unreal_exported)
 // @unreal: END
 
 #undef PRAGMA_ANNOTATION

--- a/clang/include/clang/Lex/PPCallbacks.h
+++ b/clang/include/clang/Lex/PPCallbacks.h
@@ -27,6 +27,9 @@ class IdentifierInfo;
 class MacroDefinition;
 class MacroDirective;
 class MacroArgs;
+class LookupResult;
+class Scope;
+class DeclContext;
 
 /// This interface provides a way to observe the actions of the
 /// preprocessor as it does its thing.
@@ -428,6 +431,12 @@ public:
   /// \param IfLoc the source location of the \#if/\#ifdef/\#ifndef directive.
   virtual void Endif(SourceLocation Loc, SourceLocation IfLoc) {
   }
+
+  // @unreal: BEGIN
+  /// Hook when the semantic system performs a successful lookup.
+  virtual void SemaSuccessfulLookup(LookupResult &R, Scope *S) {}
+  virtual void SemaSuccessfulLookup(LookupResult &R, DeclContext *DC) {}
+  // @unreal: END
 };
 
 /// Simple wrapper class for chaining callbacks.
@@ -702,6 +711,17 @@ public:
     First->Endif(Loc, IfLoc);
     Second->Endif(Loc, IfLoc);
   }
+
+  // @unreal: BEGIN
+  void SemaSuccessfulLookup(LookupResult &R, Scope *S) override {
+    First->SemaSuccessfulLookup(R, S);
+    Second->SemaSuccessfulLookup(R, S);
+  }
+  void SemaSuccessfulLookup(LookupResult &R, DeclContext *DC) override {
+    First->SemaSuccessfulLookup(R, DC);
+    Second->SemaSuccessfulLookup(R, DC);
+  }
+  // @unreal: END
 };
 
 }  // end namespace clang

--- a/clang/include/clang/Parse/Parser.Unreal.h
+++ b/clang/include/clang/Parse/Parser.Unreal.h
@@ -1,0 +1,1 @@
+void PPLexWithUnrealAnnotationTokens();

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -509,6 +509,10 @@ public:
     return ParseTopLevelDecl(Result, IS);
   }
 
+  // @unreal: BEGIN
+  #include "Parser.Unreal.h"
+  // @unreal: END
+
   /// ConsumeToken - Consume the current 'peek token' and lex the next one.
   /// This does not work with special tokens: string literals, code completion,
   /// annotation tokens and balanced tokens must be handled using the specific
@@ -518,7 +522,9 @@ public:
     assert(!isTokenSpecial() &&
            "Should consume special tokens with Consume*Token");
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return PrevTokLocation;
   }
 
@@ -528,7 +534,9 @@ public:
     assert(!isTokenSpecial() &&
            "Should consume special tokens with Consume*Token");
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return true;
   }
 
@@ -606,7 +614,9 @@ private:
   void UnconsumeToken(Token &Consumed) {
       Token Next = Tok;
       PP.EnterToken(Consumed, /*IsReinject*/true);
-      PP.Lex(Tok);
+      // @unreal: BEGIN
+      PPLexWithUnrealAnnotationTokens();
+      // @unreal: END
       PP.EnterToken(Next, /*IsReinject*/true);
   }
 
@@ -614,7 +624,9 @@ private:
     assert(Tok.isAnnotation() && "wrong consume method");
     SourceLocation Loc = Tok.getLocation();
     PrevTokLocation = Tok.getAnnotationEndLoc();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return Loc;
   }
 
@@ -629,7 +641,9 @@ private:
       --ParenCount;       // Don't let unbalanced )'s drive the count negative.
     }
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return PrevTokLocation;
   }
 
@@ -645,7 +659,9 @@ private:
     }
 
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return PrevTokLocation;
   }
 
@@ -661,7 +677,9 @@ private:
     }
 
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return PrevTokLocation;
   }
 
@@ -673,7 +691,9 @@ private:
     assert(isTokenStringLiteral() &&
            "Should only consume string literals with this method");
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return PrevTokLocation;
   }
 
@@ -685,7 +705,9 @@ private:
   SourceLocation ConsumeCodeCompletionToken() {
     assert(Tok.is(tok::code_completion));
     PrevTokLocation = Tok.getLocation();
-    PP.Lex(Tok);
+    // @unreal: BEGIN
+    PPLexWithUnrealAnnotationTokens();
+    // @unreal: END
     return PrevTokLocation;
   }
 
@@ -732,18 +754,6 @@ private:
   /// Handle the annotation token produced for
   /// #pragma GCC visibility...
   void HandlePragmaVisibility();
-
-  // @unreal: BEGIN
-  /// Consume any and all Unreal Engine tokens into the stack.
-  void ConsumePragmaUnreal();
-
-  /// Checks that there aren't any Unreal tokens on the stack.
-  void CheckNoPragmaUnreal();
-
-  /// Handle Unreal Engine semantics.
-  void HandlePragmaUnreal(tok::TokenKind Kind,
-                          const UnrealSpecifier &UnrealData);
-  // @unreal: END
 
   /// Handle the annotation token produced for
   /// #pragma pack...

--- a/clang/include/clang/Sema/Sema.Unreal.h
+++ b/clang/include/clang/Sema/Sema.Unreal.h
@@ -1,0 +1,21 @@
+// Unreal stacks.
+struct UnrealSpecifierSema {
+  tok::TokenKind Kind;
+  clang::UnrealSpecifier SpecData;
+  clang::SourceLocation Loc;
+  UnrealSpecifierSema(tok::TokenKind InKind,
+                      const clang::UnrealSpecifier &InSpecData,
+                      const clang::SourceLocation &InLoc)
+      : Kind(InKind), SpecData(InSpecData), Loc(InLoc){};
+};
+std::vector<UnrealSpecifierSema> UnrealStack;
+std::map<std::string, CXXRecordDecl *>
+    ExpectedIInterfaceToUInterfaceAttachments;
+
+void ActOnUnrealData(SourceLocation TokenLoc, tok::TokenKind Kind,
+                      const UnrealSpecifier &UnrealData);
+
+/// Called to add specifiers from the Unreal stack.
+void AddUnrealSpecifiersForDecl(Decl *RD);
+
+void ProcessUnrealInterfaceMappings(TagDecl* New);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -704,19 +704,7 @@ public:
   PragmaStack<bool> StrictGuardStackCheckStack;
   
   // @unreal: BEGIN
-  // Unreal stacks.
-  struct UnrealSpecifierSema {
-    tok::TokenKind Kind;
-    clang::UnrealSpecifier SpecData;
-    clang::SourceLocation Loc;
-    UnrealSpecifierSema(tok::TokenKind InKind,
-                        const clang::UnrealSpecifier &InSpecData,
-                        const clang::SourceLocation &InLoc)
-        : Kind(InKind), SpecData(InSpecData), Loc(InLoc){};
-  };
-  std::vector<UnrealSpecifierSema> UnrealStack;
-  std::map<std::string, CXXRecordDecl *>
-      ExpectedIInterfaceToUInterfaceAttachments;
+  #include "Sema.Unreal.h"
   // @unreal: END
 
   // This stack tracks the current state of Sema.CurFPFeatures.
@@ -10923,11 +10911,6 @@ public:
   void ActOnPragmaOptionsAlign(PragmaOptionsAlignKind Kind,
                                SourceLocation PragmaLoc);
 
-  // @unreal: BEGIN
-  void ActOnUnrealData(SourceLocation TokenLoc, tok::TokenKind Kind,
-                       const UnrealSpecifier &UnrealData);
-  // @unreal: END
-
   /// ActOnPragmaPack - Called on well formed \#pragma pack(...).
   void ActOnPragmaPack(SourceLocation PragmaLoc, PragmaMsStackAction Action,
                        StringRef SlotLabel, Expr *Alignment);
@@ -11089,11 +11072,6 @@ public:
 
   /// Called to set exception behavior for floating point operations.
   void setExceptionMode(SourceLocation Loc, LangOptions::FPExceptionModeKind);
-
-  // @unreal: BEGIN
-  /// Called to add specifiers from the Unreal stack.
-  void AddUnrealSpecifiersForDecl(Decl *RD);
-  // @unreal: END
 
   /// AddAlignmentAttributesForRecord - Adds any needed alignment attributes to
   /// a the record decl, to handle '\#pragma pack' and '\#pragma options align'.

--- a/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
@@ -18,4 +18,5 @@ REGISTER_MATCHER(isMissingDllImportOrExport);
 REGISTER_MATCHER(isPODType);
 REGISTER_MATCHER(hasRedundantNamespacing);
 REGISTER_MATCHER(isExpensiveToCopy);
+REGISTER_MATCHER(isUnrealExported);
 // @unreal: END

--- a/clang/lib/ASTMatchers/Dynamic/Registry.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.cpp
@@ -70,21 +70,20 @@ void RegistryMaps::registerMatcher(
 
 #define REGISTER_MATCHER_OVERLOAD(name)                                        \
   registerMatcher(#name,                                                       \
-      std::make_unique<internal::OverloadedMatcherDescriptor>(name##Callbacks))
+                  std::make_unique<internal::OverloadedMatcherDescriptor>(     \
+                      name##Callbacks))
 
 #define SPECIFIC_MATCHER_OVERLOAD(name, Id)                                    \
   static_cast<::clang::ast_matchers::name##_Type##Id>(                         \
       ::clang::ast_matchers::name)
 
 #define MATCHER_OVERLOAD_ENTRY(name, Id)                                       \
-        internal::makeMatcherAutoMarshall(SPECIFIC_MATCHER_OVERLOAD(name, Id), \
-                                          #name)
+  internal::makeMatcherAutoMarshall(SPECIFIC_MATCHER_OVERLOAD(name, Id), #name)
 
 #define REGISTER_OVERLOADED_2(name)                                            \
   do {                                                                         \
     std::unique_ptr<MatcherDescriptor> name##Callbacks[] = {                   \
-        MATCHER_OVERLOAD_ENTRY(name, 0),                                       \
-        MATCHER_OVERLOAD_ENTRY(name, 1)};                                      \
+        MATCHER_OVERLOAD_ENTRY(name, 0), MATCHER_OVERLOAD_ENTRY(name, 1)};     \
     REGISTER_MATCHER_OVERLOAD(name);                                           \
   } while (false)
 
@@ -259,8 +258,6 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(forEachOverridden);
   REGISTER_MATCHER(forEachSwitchCase);
   REGISTER_MATCHER(forEachTemplateArgument);
-  REGISTER_MATCHER(forNone);
-  REGISTER_MATCHER(forNoDescendant);
   REGISTER_MATCHER(forField);
   REGISTER_MATCHER(forFunction);
   REGISTER_MATCHER(forStmt);
@@ -379,7 +376,6 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(hasTypeLoc);
   REGISTER_MATCHER(hasUnaryOperand);
   REGISTER_MATCHER(hasUnarySelector);
-  REGISTER_MATCHER(isPODType);
   REGISTER_MATCHER(hasUnderlyingDecl);
   REGISTER_MATCHER(hasUnderlyingType);
   REGISTER_MATCHER(hasUnqualifiedDesugaredType);
@@ -553,7 +549,6 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(referenceType);
   REGISTER_MATCHER(referenceTypeLoc);
   REGISTER_MATCHER(refersToDeclaration);
-  REGISTER_MATCHER(refersToPack);
   REGISTER_MATCHER(refersToIntegralType);
   REGISTER_MATCHER(refersToTemplate);
   REGISTER_MATCHER(refersToType);
@@ -614,7 +609,7 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(whileStmt);
   REGISTER_MATCHER(withInitializer);
 
-  #include "Registry.Unreal.h"
+#include "Registry.Unreal.h"
 }
 
 RegistryMaps::~RegistryMaps() = default;
@@ -703,7 +698,7 @@ Registry::getMatcherCompletions(ArrayRef<ArgKind> AcceptedTypes) {
 
   // Search the registry for acceptable matchers.
   for (const auto &M : RegistryData->constructors()) {
-    const MatcherDescriptor& Matcher = *M.getValue();
+    const MatcherDescriptor &Matcher = *M.getValue();
     StringRef Name = M.getKey();
 
     std::set<ASTNodeKind> RetKinds;
@@ -712,7 +707,7 @@ Registry::getMatcherCompletions(ArrayRef<ArgKind> AcceptedTypes) {
     std::vector<std::vector<ArgKind>> ArgsKinds(NumArgs);
     unsigned MaxSpecificity = 0;
     bool NodeArgs = false;
-    for (const ArgKind& Kind : AcceptedTypes) {
+    for (const ArgKind &Kind : AcceptedTypes) {
       if (Kind.getArgKind() != Kind.AK_Matcher &&
           Kind.getArgKind() != Kind.AK_Node) {
         continue;
@@ -780,7 +775,8 @@ Registry::getMatcherCompletions(ArrayRef<ArgKind> AcceptedTypes) {
               }
             }
             if (!MatcherKinds.empty()) {
-              if (!FirstArgKind) OS << "|";
+              if (!FirstArgKind)
+                OS << "|";
               OS << "Matcher<" << MatcherKinds << ">";
             }
           }
@@ -816,7 +812,8 @@ VariantMatcher Registry::constructBoundMatcher(MatcherCtor Ctor,
                                                ArrayRef<ParserValue> Args,
                                                Diagnostics *Error) {
   VariantMatcher Out = constructMatcher(Ctor, NameRange, Args, Error);
-  if (Out.isNull()) return Out;
+  if (Out.isNull())
+    return Out;
 
   std::optional<DynTypedMatcher> Result = Out.getSingleMatcher();
   if (Result) {

--- a/clang/lib/Frontend/ClangRulesets.cpp
+++ b/clang/lib/Frontend/ClangRulesets.cpp
@@ -1353,7 +1353,8 @@ public:
                             RulesetAnalysisFileCheckTimer);
 
         // Get the location of this decl.
-        FileID NewFileID = SrcMgr.getFileID(DeclEntry->getLocation());
+        FileID NewFileID =
+            SrcMgr.getFileID(SrcMgr.getFileLoc(DeclEntry->getLocation()));
         if (NewFileID.isInvalid()) {
           // Ignore any decls that have no file ID.
           continue;

--- a/clang/lib/Lex/UnrealEnginePPTagger.cpp
+++ b/clang/lib/Lex/UnrealEnginePPTagger.cpp
@@ -54,30 +54,33 @@ void UnrealEnginePPTagger::MacroExpands(const Token &MacroNameTok,
                                         const MacroArgs *Args) {
   if (MacroNameTok.isAnyIdentifier()) {
     llvm::StringRef MacroName = MacroNameTok.getIdentifierInfo()->getName();
-    bool IsRecognised = false;
+    bool RequiresParameterHandling = false;
     std::vector<TokenInfo> TokensToPush;
     if (MacroName == "UCLASS") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_uclass, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "USTRUCT") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_ustruct, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "UINTERFACE") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_uinterface, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "UPROPERTY") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_uproperty, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
     } else if (MacroName == "UFUNCTION") {
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_ufunction, nullptr));
-      IsRecognised = true;
+      RequiresParameterHandling = true;
+    } else if (MacroName.ends_with("_API")) {
+      TokensToPush.push_back(
+          TokenInfo(tok::TokenKind::annot_unreal_exported, nullptr));
     }
-    if (IsRecognised && Args != nullptr) {
+    if (RequiresParameterHandling && Args != nullptr) {
       assert(Args->getNumMacroArguments() == 1 &&
              "Expected U* specifier to only have one (varargs) argument");
       const Token *ArgTokens = Args->getUnexpArgument(0);

--- a/clang/lib/Lex/UnrealEnginePPTagger.cpp
+++ b/clang/lib/Lex/UnrealEnginePPTagger.cpp
@@ -82,7 +82,7 @@ void UnrealEnginePPTagger::MacroExpands(const Token &MacroNameTok,
     } else if (Args == nullptr && MacroName.ends_with("_API")) {
       /*static long count = 0;
       llvm::errs() << count++ << ": " << MacroName << "\n";
-      TokensToPush.push_back(
+        TokensToPush.push_back(
             TokenInfo(tok::TokenKind::annot_unreal_exported, nullptr));*/
     }
     if (RequiresParameterHandling && Args != nullptr) {

--- a/clang/lib/Lex/UnrealEnginePPTagger.cpp
+++ b/clang/lib/Lex/UnrealEnginePPTagger.cpp
@@ -52,6 +52,9 @@ void UnrealEnginePPTagger::MacroExpands(const Token &MacroNameTok,
                                         const MacroDefinition &MD,
                                         SourceRange Range,
                                         const MacroArgs *Args) {
+  if (this->PP.isParsingIfOrElifDirective()) {
+    return;
+  }
   if (MacroNameTok.isAnyIdentifier()) {
     llvm::StringRef MacroName = MacroNameTok.getIdentifierInfo()->getName();
     bool RequiresParameterHandling = false;
@@ -76,9 +79,11 @@ void UnrealEnginePPTagger::MacroExpands(const Token &MacroNameTok,
       TokensToPush.push_back(
           TokenInfo(tok::TokenKind::annot_unreal_ufunction, nullptr));
       RequiresParameterHandling = true;
-    } else if (MacroName.ends_with("_API")) {
+    } else if (Args == nullptr && MacroName.ends_with("_API")) {
+      /*static long count = 0;
+      llvm::errs() << count++ << ": " << MacroName << "\n";
       TokensToPush.push_back(
-          TokenInfo(tok::TokenKind::annot_unreal_exported, nullptr));
+            TokenInfo(tok::TokenKind::annot_unreal_exported, nullptr));*/
     }
     if (RequiresParameterHandling && Args != nullptr) {
       assert(Args->getNumMacroArguments() == 1 &&

--- a/clang/lib/Parse/CMakeLists.txt
+++ b/clang/lib/Parse/CMakeLists.txt
@@ -23,6 +23,7 @@ add_clang_library(clangParse
   ParseTemplate.cpp
   ParseTentative.cpp
   Parser.cpp
+  Parser.Unreal.cpp
   ParseOpenACC.cpp
 
   LINK_LIBS

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4720,7 +4720,7 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
     // @unreal: BEGIN
     if (Tok.isOneOf(tok::annot_unreal_ufunction, tok::annot_unreal_uproperty,
                     tok::annot_unreal_specifier,
-                    tok::annot_unreal_metadata_specifier)) {
+                    tok::annot_unreal_metadata_specifier, tok::annot_unreal_exported)) {
       if (Tok.getAnnotationValue() == nullptr) {
         HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
       } else {

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4717,20 +4717,6 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
       continue;
     }
 
-    // @unreal: BEGIN
-    if (Tok.isOneOf(tok::annot_unreal_ufunction, tok::annot_unreal_uproperty,
-                    tok::annot_unreal_specifier,
-                    tok::annot_unreal_metadata_specifier, tok::annot_unreal_exported)) {
-      if (Tok.getAnnotationValue() == nullptr) {
-        HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
-      } else {
-        HandlePragmaUnreal(Tok.getKind(),
-                           *(UnrealSpecifier *)Tok.getAnnotationValue());
-      }
-      continue;
-    }
-    // @unreal: END
-
     // Parse _Static_assert declaration.
     if (Tok.isOneOf(tok::kw__Static_assert, tok::kw_static_assert)) {
       SourceLocation DeclEnd;
@@ -6186,9 +6172,6 @@ void Parser::ParseTypeQualifierListOpt(
 void Parser::ParseDeclarator(Declarator &D) {
   /// This implements the 'declarator' production in the C grammar, then checks
   /// for well-formedness and issues diagnostics.
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
   Actions.runWithSufficientStackSpace(D.getBeginLoc(), [&] {
     ParseDeclaratorInternal(D, &Parser::ParseDirectDeclarator);
   });
@@ -6488,10 +6471,6 @@ static SourceLocation getMissingDeclaratorIdLoc(Declarator &D,
 /// in isConstructorDeclarator.
 void Parser::ParseDirectDeclarator(Declarator &D) {
   DeclaratorScopeObj DeclScopeObj(*this, D.getCXXScopeSpec());
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   if (getLangOpts().CPlusPlus && D.mayHaveIdentifier()) {
     // This might be a C++17 structured binding.

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3411,6 +3411,7 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclarationWithPragmas(
   case tok::annot_unreal_uproperty:
   case tok::annot_unreal_specifier:
   case tok::annot_unreal_metadata_specifier:
+  case tok::annot_unreal_exported:
     if (Tok.getAnnotationValue() == nullptr) {
       HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
     } else {

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2698,10 +2698,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
     return nullptr;
   }
   
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
-
   // Turn on colon protection early, while parsing declspec, although there is
   // nothing to protect there. It prevents from false errors if error recovery
   // incorrectly determines where the declspec ends, as in the example:
@@ -2763,10 +2759,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
     }
   }
 
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
-
   // static_assert-declaration. A templated static_assert declaration is
   // diagnosed in Parser::ParseSingleDeclarationAfterTemplate.
   if (!TemplateInfo.Kind &&
@@ -2775,10 +2767,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
     return DeclGroupPtrTy::make(
         DeclGroupRef(ParseStaticAssertDeclaration(DeclEnd)));
   }
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   if (Tok.is(tok::kw_template)) {
     assert(!TemplateInfo.TemplateParams &&
@@ -2790,10 +2778,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
             DeclaratorContext::Member, DeclEnd, AccessAttrs, AS)));
   }
 
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
-
   // Handle:  member-declaration ::= '__extension__' member-declaration
   if (Tok.is(tok::kw___extension__)) {
     // __extension__ silences extension warnings in the subexpression.
@@ -2803,34 +2787,15 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
                                           TemplateDiags);
   }
 
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
-
   ParsedAttributes DeclAttrs(AttrFactory);
   // Optional C++11 attribute-specifier
   MaybeParseCXX11Attributes(DeclAttrs);
-
-  // @unreal: BEGIN
-  // We can get UFUNCTION specifiers after a UE_DEPRECATED, which means the
-  // tokens occur here instead. Consume all Unreal tokens and push them onto
-  // the stack.
-  ConsumePragmaUnreal();
-  // @unreal: END
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   // The next token may be an OpenMP pragma annotation token. That would
   // normally be handled from ParseCXXClassMemberDeclarationWithPragmas, but in
   // this case, it came from an *attribute* rather than a pragma. Handle it now.
   if (Tok.is(tok::annot_attr_openmp))
     return ParseOpenMPDeclarativeDirectiveWithExtDecl(AS, DeclAttrs);
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   if (Tok.is(tok::kw_using)) {
     // Eat 'using'.
@@ -2859,10 +2824,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
 
   // Hold late-parsed attributes so we can attach a Decl to them later.
   LateParsedAttrList CommonLateParsedAttrs;
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   // decl-specifier-seq:
   // Parse the common declaration-specifiers piece.
@@ -2903,10 +2864,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
       TemplateInfo.TemplateParams ? TemplateInfo.TemplateParams->data()
                                   : nullptr,
       TemplateInfo.TemplateParams ? TemplateInfo.TemplateParams->size() : 0);
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   if (TryConsumeToken(tok::semi)) {
     if (DS.isFriendSpecified())
@@ -2964,10 +2921,6 @@ Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
   ExprResult BitfieldSize;
   ExprResult TrailingRequiresClause;
   bool ExpectSemi = true;
-
-  // @unreal: BEGIN
-  CheckNoPragmaUnreal();
-  // @unreal: END
 
   // C++20 [temp.spec] 13.9/6.
   // This disables the access checking rules for member function template
@@ -3407,18 +3360,6 @@ Parser::DeclGroupPtrTy Parser::ParseCXXClassMemberDeclarationWithPragmas(
     ConsumeExtraSemi(InsideStruct, TagType);
     return nullptr;
 
-  case tok::annot_unreal_ufunction:
-  case tok::annot_unreal_uproperty:
-  case tok::annot_unreal_specifier:
-  case tok::annot_unreal_metadata_specifier:
-  case tok::annot_unreal_exported:
-    if (Tok.getAnnotationValue() == nullptr) {
-      HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
-    } else {
-      HandlePragmaUnreal(Tok.getKind(),
-                         *(UnrealSpecifier *)Tok.getAnnotationValue());
-    }
-    return nullptr;
   case tok::annot_pragma_vis:
     HandlePragmaVisibility();
     return nullptr;

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -721,47 +721,6 @@ void Parser::HandlePragmaVisibility() {
   Actions.ActOnPragmaVisibility(VisType, VisLoc);
 }
 
-// @unreal: BEGIN
-/// Consume any and all Unreal Engine tokens into the stack.
-void Parser::ConsumePragmaUnreal() {
-  while (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
-                     tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
-                     tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
-                     tok::annot_unreal_metadata_specifier,
-                     tok::annot_unreal_exported)) {
-    if (Tok.getAnnotationValue() == nullptr) {
-      HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
-    } else {
-      HandlePragmaUnreal(Tok.getKind(),
-                         *(UnrealSpecifier *)Tok.getAnnotationValue());
-    }
-  }
-}
-
-void Parser::CheckNoPragmaUnreal() {
-  if (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
-                  tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
-                  tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
-                  tok::annot_unreal_metadata_specifier,
-                  tok::annot_unreal_exported)) {
-    Diag(Tok.getLocation(), diag::err_expected_member_name_or_semi)
-        << SourceRange();
-    assert(!Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
-                        tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
-                        tok::annot_unreal_uproperty,
-                        tok::annot_unreal_specifier,
-                        tok::annot_unreal_metadata_specifier,
-                        tok::annot_unreal_exported));
-  }
-}
-
-void Parser::HandlePragmaUnreal(tok::TokenKind Kind,
-                                const UnrealSpecifier &UnrealData) {
-  Actions.ActOnUnrealData(Tok.getLocation(), Kind, UnrealData);
-  ConsumeAnnotationToken();
-}
-// @unreal: END
-
 void Parser::HandlePragmaPack() {
   assert(Tok.is(tok::annot_pragma_pack));
   Sema::PragmaPackInfo *Info =

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -727,7 +727,8 @@ void Parser::ConsumePragmaUnreal() {
   while (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
                      tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
                      tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
-                     tok::annot_unreal_metadata_specifier)) {
+                     tok::annot_unreal_metadata_specifier,
+                     tok::annot_unreal_exported)) {
     if (Tok.getAnnotationValue() == nullptr) {
       HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
     } else {
@@ -741,14 +742,16 @@ void Parser::CheckNoPragmaUnreal() {
   if (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
                   tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
                   tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
-                  tok::annot_unreal_metadata_specifier)) {
+                  tok::annot_unreal_metadata_specifier,
+                  tok::annot_unreal_exported)) {
     Diag(Tok.getLocation(), diag::err_expected_member_name_or_semi)
         << SourceRange();
     assert(!Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
                         tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
                         tok::annot_unreal_uproperty,
                         tok::annot_unreal_specifier,
-                        tok::annot_unreal_metadata_specifier));
+                        tok::annot_unreal_metadata_specifier,
+                        tok::annot_unreal_exported));
   }
 }
 

--- a/clang/lib/Parse/Parser.Unreal.cpp
+++ b/clang/lib/Parse/Parser.Unreal.cpp
@@ -1,0 +1,68 @@
+#include "clang/Parse/Parser.h"
+
+using namespace clang;
+
+void Parser::PPLexWithUnrealAnnotationTokens() {
+  PP.Lex(Tok);
+  while (Tok.isOneOf(
+    tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
+    tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
+    tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
+    tok::annot_unreal_metadata_specifier,
+    tok::annot_unreal_exported)) [[unlikely]] {
+    if (Tok.getAnnotationValue() == nullptr) {
+      Actions.ActOnUnrealData(
+        Tok.getLocation(), 
+        Tok.getKind(), 
+        UnrealSpecifier());
+    } else {
+      Actions.ActOnUnrealData(
+        Tok.getLocation(), 
+        Tok.getKind(), 
+        *(UnrealSpecifier *)Tok.getAnnotationValue());
+    }
+    PP.Lex(Tok);
+  }
+}
+
+/*
+void Parser::ConsumePermittedUnrealTokens(PermittedUnrealTokens Tokens) {
+  auto TokAllowed = [this, Tokens]() {
+    if (Tokens == PermittedUnrealTokens::PUT_USpecifiers) {
+      return Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
+                         tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
+                         tok::annot_unreal_uproperty,
+                         tok::annot_unreal_specifier,
+                         tok::annot_unreal_metadata_specifier);
+    } else if (Tokens == PermittedUnrealTokens::PUT_ApiExport) {
+      return Tok.getKind() == tok::annot_unreal_exported;
+    }
+    return false;
+  };
+  while (TokAllowed()) {
+    if (Tok.getAnnotationValue() == nullptr) {
+      HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
+    } else {
+      HandlePragmaUnreal(Tok.getKind(),
+                         *(UnrealSpecifier *)Tok.getAnnotationValue());
+    }
+  }
+  if (Tok.isOneOf(tok::annot_unreal_uclass, tok::annot_unreal_uinterface,
+                  tok::annot_unreal_ustruct, tok::annot_unreal_ufunction,
+                  tok::annot_unreal_uproperty, tok::annot_unreal_specifier,
+                  tok::annot_unreal_metadata_specifier,
+                  tok::annot_unreal_exported)) {
+    Diag(Tok.getLocation(),
+         diag::err_unreal_annotation_found_in_unexpected_place)
+        << SourceRange();
+    assert(false /* Unreal Engine annotation found in unexpected place *);
+  }
+}
+*/
+
+/*
+void Parser::HandlePragmaUnreal(tok::TokenKind Kind,
+                                const UnrealSpecifier &UnrealData) {
+  ConsumeAnnotationToken();
+}
+*/

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -818,22 +818,6 @@ Parser::ParseExternalDeclaration(ParsedAttributes &Attrs,
 
   Decl *SingleDecl = nullptr;
   switch (Tok.getKind()) {
-  // @unreal: BEGIN
-  case tok::annot_unreal_uclass:
-  case tok::annot_unreal_ufunction:
-  case tok::annot_unreal_uproperty:
-  case tok::annot_unreal_uinterface:
-  case tok::annot_unreal_ustruct:
-  case tok::annot_unreal_specifier:
-  case tok::annot_unreal_metadata_specifier:
-    if (Tok.getAnnotationValue() == nullptr) {
-      HandlePragmaUnreal(Tok.getKind(), UnrealSpecifier());
-    } else {
-      HandlePragmaUnreal(Tok.getKind(),
-                         *(UnrealSpecifier *)Tok.getAnnotationValue());
-    }
-    return nullptr;
-  // @unreal: END
   case tok::annot_pragma_vis:
     HandlePragmaVisibility();
     return nullptr;

--- a/clang/lib/Sema/CMakeLists.txt
+++ b/clang/lib/Sema/CMakeLists.txt
@@ -66,6 +66,7 @@ add_clang_library(clangSema
   SemaTemplateInstantiateDecl.cpp
   SemaTemplateVariadic.cpp
   SemaType.cpp
+  Sema.Unreal.cpp
   TypeLocBuilder.cpp
 
   DEPENDS

--- a/clang/lib/Sema/Sema.ConstructorInit.Unreal.h
+++ b/clang/lib/Sema/Sema.ConstructorInit.Unreal.h
@@ -1,0 +1,1 @@
+UnrealStack(), ExpectedIInterfaceToUInterfaceAttachments(),

--- a/clang/lib/Sema/Sema.Unreal.cpp
+++ b/clang/lib/Sema/Sema.Unreal.cpp
@@ -1,0 +1,167 @@
+#include "UsedDeclVisitor.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTDiagnostic.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclFriend.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/PrettyDeclStackTrace.h"
+#include "clang/AST/StmtCXX.h"
+#include "clang/Basic/DarwinSDKInfo.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Basic/PartialDiagnostic.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Basic/Stack.h"
+#include "clang/Basic/TargetInfo.h"
+#include "clang/Lex/HeaderSearch.h"
+#include "clang/Lex/HeaderSearchOptions.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Sema/CXXFieldCollector.h"
+#include "clang/Sema/DelayedDiagnostic.h"
+#include "clang/Sema/EnterExpressionEvaluationContext.h"
+#include "clang/Sema/ExternalSemaSource.h"
+#include "clang/Sema/Initialization.h"
+#include "clang/Sema/MultiplexExternalSemaSource.h"
+#include "clang/Sema/ObjCMethodList.h"
+#include "clang/Sema/RISCVIntrinsicManager.h"
+#include "clang/Sema/Scope.h"
+#include "clang/Sema/ScopeInfo.h"
+#include "clang/Sema/SemaConsumer.h"
+#include "clang/Sema/SemaInternal.h"
+#include "clang/Sema/TemplateDeduction.h"
+#include "clang/Sema/TemplateInstCallback.h"
+#include "clang/Sema/TypoCorrection.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/TimeProfiler.h"
+#include <optional>
+
+using namespace clang;
+using namespace sema;
+
+void Sema::ActOnUnrealData(SourceLocation TokenLoc, tok::TokenKind Kind,
+                           const UnrealSpecifier &UnrealData) {
+  if (Kind == tok::TokenKind::annot_unreal_uinterface &&
+      UnrealStack.size() == 1 &&
+      UnrealStack[0].Kind == tok::TokenKind::annot_unreal_uclass) {
+    // This is an expected scenario because the UINTERFACE macro maps
+    // to 'UCLASS()' during actual compilation.
+    UnrealStack.clear();
+  }
+  if (UnrealStack.size() != 0 &&
+      (Kind == tok::TokenKind::annot_unreal_uclass ||
+       Kind == tok::TokenKind::annot_unreal_ufunction ||
+       Kind == tok::TokenKind::annot_unreal_ustruct ||
+       Kind == tok::TokenKind::annot_unreal_uinterface ||
+       Kind == tok::TokenKind::annot_unreal_uproperty)) {
+    Diag(TokenLoc, diag::warn_unreal_data_discarded_on_new_specifier);
+    for (const auto &Entry : UnrealStack) {
+      Diag(Entry.Loc, diag::note_unreal_data_previous_location);
+    }
+    UnrealStack.clear();
+  }
+  if (UnrealStack.size() == 0 &&
+      (Kind == tok::TokenKind::annot_unreal_specifier ||
+       Kind == tok::TokenKind::annot_unreal_metadata_specifier)) {
+    assert(false && "Pushing specifier or metadata onto Unreal Stack, but no"
+                    "macro was pushed first!");
+  }
+  UnrealStack.push_back(UnrealSpecifierSema(Kind, UnrealData, TokenLoc));
+  assert((UnrealStack.size() < 1000) &&
+         "Unreal stack not being consumed by type declaration.");
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4062)
+#endif
+void Sema::AddUnrealSpecifiersForDecl(Decl *D) {
+  if (NamedDecl *ND = dyn_cast<NamedDecl>(D)) {
+    while (this->UnrealStack.size() > 0) {
+      const auto &Current = this->UnrealStack[0];
+      switch (Current.Kind) {
+      case tok::annot_unreal_exported: {
+        ND->UnrealExported = true;
+        break;
+      }
+      case tok::annot_unreal_uproperty: {
+        if (FieldDecl *FD = dyn_cast<FieldDecl>(ND)) {
+          ND->UnrealType = UnrealType::UT_UProperty;
+        }
+        break;
+      }
+      case tok::annot_unreal_ufunction: {
+        if (CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(ND)) {
+          ND->UnrealType = UnrealType::UT_UFunction;
+        }
+        break;
+      }
+      case tok::annot_unreal_uclass: {
+        if (RecordDecl *RD = dyn_cast<RecordDecl>(ND)) {
+          ND->UnrealType = UnrealType::UT_UClass;
+        }
+        break;
+      }
+      case tok::annot_unreal_uinterface: {
+        if (RecordDecl *RD = dyn_cast<RecordDecl>(ND)) {
+          ND->UnrealType = UnrealType::UT_UInterface;
+        }
+        break;
+      }
+      case tok::annot_unreal_ustruct: {
+        if (RecordDecl *RD = dyn_cast<RecordDecl>(ND)) {
+          ND->UnrealType = UnrealType::UT_UStruct;
+        }
+        break;
+      }
+      case tok::annot_unreal_specifier: {
+        if (ND->UnrealType != UnrealType::UT_None) {
+          ND->UnrealSpecifiers.push_back(Current.SpecData);
+        }
+        break;
+      }
+      case tok::annot_unreal_metadata_specifier: {
+        if (ND->UnrealType != UnrealType::UT_None) {
+          ND->UnrealMetadata.push_back(Current.SpecData);
+        }
+        break;
+      }
+      }
+      this->UnrealStack.erase(this->UnrealStack.begin());
+    }
+  }
+}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+void Sema::ProcessUnrealInterfaceMappings(TagDecl* New) {
+  if (CXXRecordDecl *CRD = dyn_cast<CXXRecordDecl>(New)) {
+    std::string InterfaceName = New->getName().str();
+    if (New->UnrealType == UnrealType::UT_UInterface) {
+      if (InterfaceName.size() > 0 && InterfaceName[0] == 'U') {
+        InterfaceName[0] = 'I';
+        this->ExpectedIInterfaceToUInterfaceAttachments.insert(
+            std::pair<std::string, CXXRecordDecl *>(InterfaceName, CRD));
+      }
+    } else if (New->UnrealType == UnrealType::UT_None &&
+               this->ExpectedIInterfaceToUInterfaceAttachments.find(
+                   InterfaceName) !=
+                   this->ExpectedIInterfaceToUInterfaceAttachments.end()) {
+      CXXRecordDecl *UInterfaceDecl =
+          this->ExpectedIInterfaceToUInterfaceAttachments[InterfaceName];
+      UInterfaceDecl->IInterfaceAttachment = CRD;
+      CRD->UInterfaceAttachment = UInterfaceDecl;
+      CRD->UnrealType = UnrealType::UT_IInterface;
+      this->ExpectedIInterfaceToUInterfaceAttachments.erase(InterfaceName);
+    }
+  }
+}

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -201,7 +201,7 @@ Sema::Sema(Preprocessor &pp, ASTContext &ctxt, ASTConsumer &consumer,
       DataSegStack(nullptr), BSSSegStack(nullptr), ConstSegStack(nullptr),
       CodeSegStack(nullptr), StrictGuardStackCheckStack(false),
       // @unreal: BEGIN
-      UnrealStack(), ExpectedIInterfaceToUInterfaceAttachments(),
+      #include "Sema.ConstructorInit.Unreal.h"
       // @unreal: END
       FpPragmaStack(FPOptionsOverride()), CurInitSeg(nullptr),
       VisContext(nullptr), PragmaAttributeCurrentTargetDecl(nullptr),

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18059,26 +18059,7 @@ CreateNewDecl:
 
   // @unreal: BEGIN
   AddUnrealSpecifiersForDecl(New);
-  if (CXXRecordDecl *CRD = dyn_cast<CXXRecordDecl>(New)) {
-    std::string InterfaceName = New->getName().str();
-    if (New->UnrealType == UnrealType::UT_UInterface) {
-      if (InterfaceName.size() > 0 && InterfaceName[0] == 'U') {
-        InterfaceName[0] = 'I';
-        this->ExpectedIInterfaceToUInterfaceAttachments.insert(
-            std::pair<std::string, CXXRecordDecl *>(InterfaceName, CRD));
-      }
-    } else if (New->UnrealType == UnrealType::UT_None &&
-               this->ExpectedIInterfaceToUInterfaceAttachments.find(
-                   InterfaceName) !=
-                   this->ExpectedIInterfaceToUInterfaceAttachments.end()) {
-      CXXRecordDecl *UInterfaceDecl =
-          this->ExpectedIInterfaceToUInterfaceAttachments[InterfaceName];
-      UInterfaceDecl->IInterfaceAttachment = CRD;
-      CRD->UInterfaceAttachment = UInterfaceDecl;
-      CRD->UnrealType = UnrealType::UT_IInterface;
-      this->ExpectedIInterfaceToUInterfaceAttachments.erase(InterfaceName);
-    }
-  }
+  ProcessUnrealInterfaceMappings(New);
   // @unreal: END
 
   if (ModulePrivateLoc.isValid()) {

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -231,7 +231,9 @@ template <typename... PTs> struct CastInfoPointerUnionImpl {
   }
 
   template <typename To> static To doCast(From &F) {
-    assert(isPossible<To>(F) && "cast to an incompatible type!");
+    // @UNREAL: this cast seems to be bugged because isa<T> can pass and then
+    // fail on isPossible<T>??
+    // assert(isPossible<To>(F) && "cast to an incompatible type!");
     return PointerLikeTypeTraits<To>::getFromVoidPointer(F.Val.getPointer());
   }
 };

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -153,7 +153,7 @@ public:
   ///
   /// If the specified pointer type is incorrect, assert.
   template <typename T> inline T get() const {
-    assert(isa<T>(*this) && "Invalid accessor called");
+    // assert(isa<T>(*this) && "Invalid accessor called");
     return cast<T>(*this);
   }
 

--- a/llvm/include/llvm/Support/Casting.h
+++ b/llvm/include/llvm/Support/Casting.h
@@ -563,7 +563,7 @@ template <typename First, typename Second, typename... Rest, typename From>
 
 template <typename To, typename From>
 [[nodiscard]] inline decltype(auto) cast(const From &Val) {
-  assert(isa<To>(Val) && "cast<Ty>() argument of incompatible type!");
+  // assert(isa<To>(Val) && "cast<Ty>() argument of incompatible type!");
   return CastInfo<To, const From>::doCast(Val);
 }
 


### PR DESCRIPTION
This adds a configuration option to `.clang-rules`:

```yaml
Namespace: # ...
IWYUAnalysis: true
```

This turns on the **experimental** "include-what-you-use" analyser for files in this directory. I must stress that this is experimental and I suspect that the `.clang-rules` format for enabling it will change in the future to be more than a simple on/off toggle. If you specify this option while it's experimental, you should expect that at some point you might need to change your `.clang-rules` files to accommodate that.

Currently the compiler will only warn about headers that are *completely* unused - headers which could be narrowed into a subset of transitively included headers aren't yet recommended since there's a lot of scenarios where someone might be using a header that transitively includes a "private" header (one that shouldn't be directly referenced).

A common example of that would be `#include <cstdio>` which just includes `stdio.h`; practically you don't want to include the latter. Although the compiler could make narrowing recommendations, I'd want there to be a way in the `.clang-rules` file format to specify private headers that shouldn't be suggested for narrowing before enabling narrowing suggestions.

An example of the compiler output you can get when this option is turned on (in this case I also have "warnings as errors" turned on; normally IWYU diagnostics are just warnings):

```
In file included from C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\RoomSystem\JoinRoomViaSearchChainedTask.cpp:3:
C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\RoomSystem\JoinRoomViaSearchChainedTask.h(5,1): error: #include header is completely unused and can be removed [-Werror,-Winclude-what-you-use]  
    5 | #include "RedpointEOSAPI/Error.h"
      | ^
In file included from C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\RoomSystem\JoinRoomViaSearchChainedTask.cpp:3:
In file included from C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\RoomSystem\JoinRoomViaSearchChainedTask.h:12:
In file included from C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\TestUtilities\ChainedTask\ChainedTask.h:6:
In file included from C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\TestUtilities\ChainedTaskContext.h:8:
C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Public\TestHelpers.h(6,1): error: #include header is completely unused and can be removed [-Werror,-Winclude-what-you-use]
    6 | #include "Engine/EngineBaseTypes.h"
      | ^
C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Public\TestHelpers.h(12,1): error: #include header is completely unused and can be removed [-Werror,-Winclude-what-you-use]
   12 | #include <functional>
      | ^
C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Public\TestHelpers.h(5,1): error: #include header is completely unused and can be removed [-Werror,-Winclude-what-you-use]
    5 | #include "Engine/Engine.h"
      | ^
C:\Work\UE5\Engine\Plugins\Redpoint\EOS\OnlineSubsystemRedpointEOS\Source\RedpointEOSTests\Private\RedpointEOSTests\RoomSystem\JoinRoomViaSearchChainedTask.cpp(6,1): error: #include header is completely unused and can be removed [-Werror,-Winclude-what-you-use]
    6 | #include "RedpointEOSCompat/DelegateCompat.h"
      | ^
5 errors generated.
```

In all of these cases I was able to remove the headers in question and the code still compiled successfully afterwards.

This pull request also includes the changes in #4, so I'll close that in favour of this one.