### PR TITLE
Add isNamespaceSpecifierRootedToGlobal AST matcher

### DIFF
--- a/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
@@ -19,4 +19,5 @@ REGISTER_MATCHER(isPODType);
 REGISTER_MATCHER(hasRedundantNamespacing);
 REGISTER_MATCHER(isExpensiveToCopy);
 REGISTER_MATCHER(isUnrealExported);
+REGISTER_MATCHER(isNamespaceSpecifierRootedToGlobal);
 // @unreal: END


### PR DESCRIPTION
This matches on nested namespace specifiers like '::A::B::C' but not 'A::B::C'.