### PR TITLE
[ast-match] Add isAggregate and isFullyDesignated AST matchers

### DIFF
--- a/.redpoint/build.ps1
+++ b/.redpoint/build.ps1
@@ -1,4 +1,4 @@
-param([switch] $Generate, [switch] $Install, [switch] $InstallOnly, [switch] $Debug)
+param([switch] $Generate, [switch] $Install, [switch] $InstallOnly, [switch] $Debug, [string] $UbaEngine)
 
 $global:ErrorActionPreference = 'Stop'
 
@@ -15,19 +15,31 @@ function Invoke-CmdScript {
   }
 }
 
-$UbaViaUet = (Test-Path "C:\ProgramData\UET\Current\uet.exe")
-
 Push-Location "$PSScriptRoot\.."
 try {
     # Set the build path.
     $BuildPathDebug = "build\win64\debug"
     $BuildPathRelease = "build\win64\release"
-    $LauncherFlags = @()
-    $UbaCores = @()
-    if ($UbaViaUet) {
-        $LauncherFlags += "-DCMAKE_C_COMPILER_LAUNCHER=$PSScriptRoot\uet-cmake.bat"
-        $LauncherFlags += "-DCMAKE_CXX_COMPILER_LAUNCHER=$PSScriptRoot\uet-cmake.bat"
-        $UbaCores += "-j256"
+    $CMakeCommand = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+    $CMakeCommandArguments = @(
+    )
+    $CMakeCommandGenerateArguments = @(
+        "-G",
+        "Ninja"
+    )
+    if ($null -ne $UbaEngine) {
+        $CMakeCommand = "uet";
+        if (Test-Path "C:\Work\uet\UET\uet\bin\Debug\net9.0\win-x64\uet.exe") {
+            $CMakeCommand = "C:\Work\uet\UET\uet\bin\Debug\net9.0\win-x64\uet.exe"
+        }
+        $CMakeCommandArguments = @(
+            "cmake",
+            "-e",
+            $UbaEngine,
+            "--"
+        )
+        $CMakeCommandGenerateArguments = @(
+        )
     }
 
     # Create the session ID for this build.
@@ -46,9 +58,8 @@ try {
         if (!(Test-Path $BuildPathRelease)) {
             New-Item -ItemType Directory $BuildPathRelease | Out-Null
         }
-            #-T host=x64 -A x64 `
-        & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' `
-            -G "Ninja" `
+        
+        & $CMakeCommand $CMakeCommandArguments $CMakeCommandGenerateArguments `
             "-DCMAKE_MAKE_PROGRAM=C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe" `
             "-DLLVM_ENABLE_PROJECTS:STRING=clang;lld" `
             "-DCMAKE_C_COMPILER=C:\Program Files\LLVM\bin\clang-cl.exe" `
@@ -73,8 +84,7 @@ try {
         if ($LastExitCode -ne 0) {
             exit $LastExitCode
         }
-        & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' `
-            -G "Ninja" `
+        & $CMakeCommand $CMakeCommandArguments $CMakeCommandGenerateArguments `
             "-DCMAKE_MAKE_PROGRAM=C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe" `
             "-DLLVM_ENABLE_PROJECTS:STRING=clang;lld" `
             "-DCMAKE_C_COMPILER=C:\Program Files\LLVM\bin\clang-cl.exe" `
@@ -111,15 +121,9 @@ try {
 
     # Build if not only installing.
     if (!$InstallOnly) {
-        # Start UBA worker if needed.
-        if ($UbaViaUet) {
-            Start-Process -NoNewWindow -FilePath "C:\Work\uet\UET\uet\bin\Debug\net8.0\win-x64\uet.exe" -ArgumentList @("internal", "cmake-uba-server")
-        }
-
-        & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe' `
+        & $CMakeCommand $CMakeCommandArguments `
             --build $BuildPath `
-            --config $BuildConfiguration `
-            $UbaCores
+            --config $BuildConfiguration
         if ($LastExitCode -ne 0) {
             exit $LastExitCode
         }

--- a/clang/include/clang/ASTMatchers/ASTMatchers.Unreal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.Unreal.h
@@ -532,4 +532,24 @@ AST_MATCHER(NestedNameSpecifier, isNamespaceSpecifierRootedToGlobal) {
   return false;
 }
 
+/// Matches if a CXX record decl is an aggregate type, which is a class with no user-declared 
+/// constructors, no private or protected non-static data members, no base classes, and no virtual
+/// functions (C++ [dcl.init.aggr]p1).
+AST_MATCHER(CXXRecordDecl, isAggregate) {
+  return Node.hasDefinition() && Node.isAggregate();
+}
+
+/// Matches if a init list expr is full designated (contains no initialization elements that aren't
+/// designated.
+AST_MATCHER(InitListExpr, isFullyDesignated) {
+  if (const InitListExpr *SyntacticForm =
+          Node.isSyntacticForm() ? &Node : Node.getSyntacticForm()) {
+    unsigned NumberOfDesignated = llvm::count_if(*SyntacticForm, [](auto *InitExpr) {
+      return isa<DesignatedInitExpr>(InitExpr);
+    });
+    return NumberOfDesignated == SyntacticForm->getNumInits();
+  }
+  return true;
+}
+
 // @unreal: END

--- a/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.Unreal.h
@@ -20,4 +20,6 @@ REGISTER_MATCHER(hasRedundantNamespacing);
 REGISTER_MATCHER(isExpensiveToCopy);
 REGISTER_MATCHER(isUnrealExported);
 REGISTER_MATCHER(isNamespaceSpecifierRootedToGlobal);
+REGISTER_MATCHER(isAggregate);
+REGISTER_MATCHER(isFullyDesignated);
 // @unreal: END


### PR DESCRIPTION
These new AST matchers allow you to build a rule like this:

```yaml
Rules:
- # Find initializers that are undesignated (requires C++20)
  Name: use-designated-init
  Matcher: |
    initListExpr(
      hasType(
        cxxRecordDecl(
          isAggregate(),
          matchesName("::Redpoint::EOS::API::*"),
          unless(hasAnyBase(hasType(cxxRecordDecl(has(fieldDecl())))))
        ).bind("type")
      ),
      unless(isFullyDesignated())
    ).bind("init")
  ErrorMessage: |
    initializer list should be fully designated
  Callsite: init
```

This detects any scenario where a value is initialized like `SomeType{4, 5}` when it should be initialized with `SomeType{.A = 4, .B = 5}` using the designated initializer list language feature of C++20.